### PR TITLE
feat: make Mesas header sticky

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,13 +36,15 @@
     </section>
 
     <section class="relative z-0">
-      <div class="flex items-center justify-between mb-3">
-        <h2 class="text-2xl font-bold text-gray-700">Mesas</h2>
-        <div class="text-right">
-          <div id="grand-total" class="text-xl font-extrabold">TOTAL (activas): $0.00</div>
-          <div class="flex gap-2 justify-end mt-2">
-            <button id="show-report" class="text-sm bg-blue-800 hover:bg-blue-900 text-white px-3 py-1.5 rounded-lg">Reporte del Día</button>
-            <button id="close-all" class="text-sm bg-gray-800 hover:bg-black text-white px-3 py-1.5 rounded-lg">Cobrar & Cerrar todas</button>
+      <div class="sticky top-0 bg-gray-100 z-10 pb-2">
+        <div class="flex items-center justify-between">
+          <h2 class="text-2xl font-bold text-gray-700">Mesas</h2>
+          <div class="text-right">
+            <div id="grand-total" class="text-xl font-extrabold">TOTAL (activas): $0.00</div>
+            <div class="flex gap-2 justify-end mt-2">
+              <button id="show-report" class="text-sm bg-blue-800 hover:bg-blue-900 text-white px-3 py-1.5 rounded-lg">Reporte del Día</button>
+              <button id="close-all" class="text-sm bg-gray-800 hover:bg-black text-white px-3 py-1.5 rounded-lg">Cobrar & Cerrar todas</button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- keep "Mesas" header and totals visible using sticky positioning

## Testing
- `npm test` *(fails: package.json missing)*
- `npx --yes --package puppeteer node /tmp/test-sticky.js` *(fails: 403 Forbidden to download package)*

------
https://chatgpt.com/codex/tasks/task_e_68c704fcdd1c83208f5a241aa9d774c9