### PR TITLE
Use yellow theme for table actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
                    class="flex-1 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400">
             <input id="table-note" type="text" placeholder="Nota (opcional)"
                    class="flex-1 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400">
-              <button id="add-table" class="bg-blue-500 hover:bg-blue-600 text-white font-semibold px-6 py-3 rounded-lg inline-flex items-center dark:bg-blue-600 dark:hover:bg-blue-500">
+              <button id="add-table" class="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold px-6 py-3 rounded-lg inline-flex items-center dark:bg-yellow-600 dark:hover:bg-yellow-500">
                   <span class="material-icons mr-1" aria-hidden="true">add</span>
                   Agregar
               </button>
@@ -56,11 +56,11 @@
           <div class="text-right">
             <div id="grand-total" class="text-xl font-extrabold dark:text-gray-100">TOTAL (activas): $0.00</div>
             <div class="flex gap-2 justify-end mt-2">
-                <button id="show-report" class="text-sm bg-blue-800 hover:bg-blue-900 text-white px-3 py-1.5 rounded-lg inline-flex items-center dark:bg-blue-700 dark:hover:bg-blue-600">
+                <button id="show-report" class="text-sm bg-yellow-600 hover:bg-yellow-700 text-white px-3 py-1.5 rounded-lg inline-flex items-center dark:bg-yellow-700 dark:hover:bg-yellow-600">
                   <span class="material-icons mr-1" aria-hidden="true">assessment</span>
                   Reporte del Día
                 </button>
-                <button id="close-all" class="text-sm bg-gray-800 hover:bg-black text-white px-3 py-1.5 rounded-lg inline-flex items-center dark:bg-gray-700 dark:hover:bg-gray-600">
+                <button id="close-all" class="text-sm bg-yellow-600 hover:bg-yellow-700 text-white px-3 py-1.5 rounded-lg inline-flex items-center dark:bg-yellow-700 dark:hover:bg-yellow-600">
                   <span class="material-icons mr-1" aria-hidden="true">point_of_sale</span>
                   Cobrar & Cerrar todas
                 </button>


### PR DESCRIPTION
## Summary
- style add-table button with yellow background and hover
- style report and close-all buttons with yellow theme

## Testing
- `timeout 3 python -m http.server 8001`


------
https://chatgpt.com/codex/tasks/task_e_68c709c72db883209510c96eb57016f0