### PR TITLE
fix: enable dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,16 @@
 <!DOCTYPE html>
+<!-- /index.html -->
+<!-- Main admin page for table orders -->
+<!-- Provides interface to manage tables and orders -->
+<!-- RELEVANT FILES: js/app.js, js/styles.css -->
 <html lang="es">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>Taquería "El Apá" — Órdenes por Mesa</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <title>Taquería "El Apá" — Órdenes por Mesa</title>
+  <script>tailwind.config = { darkMode: 'class' }</script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script>
       if (localStorage.theme === 'dark') {


### PR DESCRIPTION
## Summary
- enable Tailwind's class-based dark mode to activate when toggled
- document index page with header comments

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c70d5501e883209265acaf4e95246d