### PR TITLE
Improve theme toggle across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <!-- /index.html -->
 <!-- Main admin page for table orders -->
 <!-- Provides interface to manage tables and orders -->
-<!-- RELEVANT FILES: js/app.js, js/styles.css -->
+<!-- RELEVANT FILES: js/app.js, js/styles.css, js/theme.js -->
 <html lang="es">
 <head>
   <meta charset="UTF-8" />
@@ -11,18 +11,14 @@
   <script>tailwind.config = { darkMode: 'class' }</script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <script>
-      if (localStorage.theme === 'dark') {
-        document.documentElement.classList.add('dark');
-      }
-    </script>
-    <link rel="stylesheet" href="js/styles.css">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="js/theme.js"></script>
+  <link rel="stylesheet" href="js/styles.css">
   <link rel="manifest" href="./manifest.webmanifest">
   <meta name="theme-color" content="#f59e0b">
   <link rel="apple-touch-icon" href="icons/icon-192.png">
 </head>
-  <body class="bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
+  <body>
     <div class="container mx-auto max-w-7xl p-4 md:p-8">
       <header class="mb-8 flex flex-col sm:flex-row items-center justify-between text-center sm:text-left">
         <div>
@@ -124,7 +120,6 @@
   <div id="toast-wrap" class="fixed left-1/2 -translate-x-1/2 bottom-4 space-y-2 z-[10000] pointer-events-none"></div>
 
   <script src="js/app.js"></script>
-  <script src="js/theme.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
         const App = window.TaqueriaApp;
@@ -158,7 +153,7 @@
                       ? `<div data-created-at="${t.createdAt}"></div>`
                       : '';
                   card.innerHTML = `
-                      <div class=\"absolute top-3 right-3 flex gap-2\">${t.charged ? `<span class=\"badge bg-gray-800 text-white\">COBRADA</span>` : ''}</div>
+                      <div class=\"absolute top-3 right-3 flex gap-2\">${t.charged ? `<span class=\"badge bg-gray-200 text-gray-800 dark:bg-gray-800 dark:text-white\">COBRADA</span>` : ''}</div>
                       <h3 class=\"text-xl font-bold\">${t.name}</h3>
                       <p class=\"text-sm text-gray-500 dark:text-gray-400 min-h-[20px]\">${t.note || ''}</p>
                       <div class=\"mt-2 flex items-end justify-between\">
@@ -433,7 +428,7 @@
             App.AppState.currentTableId = table.id;
             App.$("#drawer-title").textContent = table.name;
               App.$("#drawer-note").textContent = table.note || "";
-              App.$("#drawer-status").innerHTML = table.charged ? `<span class="badge bg-gray-800 text-white">COBRADA</span> <span class="text-gray-500 dark:text-gray-400">— ${new Date(table.paidAt || Date.now()).toLocaleString()}</span>` : '<span class="badge bg-emerald-100 text-emerald-700">ACTIVA</span>';
+              App.$("#drawer-status").innerHTML = table.charged ? `<span class="badge bg-gray-200 text-gray-800 dark:bg-gray-800 dark:text-white">COBRADA</span> <span class="text-gray-500 dark:text-gray-400">— ${new Date(table.paidAt || Date.now()).toLocaleString()}</span>` : '<span class="badge bg-emerald-100 text-emerald-700">ACTIVA</span>';
               App.$("#table-total").textContent = App.money(App.computeTableTotal(table) + (table.charged ? table.tip : 0));
               renderMenuList(table);
               renderTableSummary(table);

--- a/js/styles.css
+++ b/js/styles.css
@@ -1,4 +1,27 @@
-body { font-family: 'Inter', sans-serif; }
+/* /js/styles.css
+   Shared styles and dark mode variables
+   Keeps UI consistent across pages
+   RELEVANT FILES: index.html, precios.html */
+
+:root {
+  --color-amber: #f59e0b;
+  --bg-light: #f3f4f6;
+  --bg-dark: #111827;
+  --text-light: #1f2937;
+  --text-dark: #f3f4f6;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: var(--bg-light);
+  color: var(--text-light);
+}
+
+.dark body {
+  background-color: var(--bg-dark);
+  color: var(--text-dark);
+}
+
 .card { transition: transform .2s ease, box-shadow .2s ease, border-color .3s ease; }
 .card:hover { transform: translateY(-3px); box-shadow: 0 10px 15px -3px rgba(0,0,0,.1), 0 4px 6px -2px rgba(0,0,0,.05); }
 .badge { font-size:.7rem; padding:.2rem .5rem; border-radius:9999px; }

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,23 +1,31 @@
 /* /js/theme.js
    Handles dark and light theme toggling
    Allows staff to switch themes for better visibility
-   RELEVANT FILES: index.html, js/styles.css */
+   RELEVANT FILES: index.html, precios.html, js/styles.css */
 
 (function() {
     const root = document.documentElement;
-    const btn = document.getElementById('theme-toggle');
-    const icon = document.getElementById('theme-icon');
-    if (!btn || !icon) return;
 
     function applyTheme(isDark) {
         root.classList.toggle('dark', isDark);
         localStorage.theme = isDark ? 'dark' : 'light';
-        icon.textContent = isDark ? 'light_mode' : 'dark_mode';
     }
 
-    btn.addEventListener('click', () => {
-        applyTheme(!root.classList.contains('dark'));
-    });
-
+    // Set initial theme early
     applyTheme(localStorage.theme === 'dark');
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const btn = document.getElementById('theme-toggle');
+        const icon = document.getElementById('theme-icon');
+        if (!btn || !icon) {
+            console.warn('Theme toggle elements not found');
+            return;
+        }
+        icon.textContent = root.classList.contains('dark') ? 'light_mode' : 'dark_mode';
+        btn.addEventListener('click', () => {
+            const isDark = root.classList.contains('dark');
+            applyTheme(!isDark);
+            icon.textContent = isDark ? 'dark_mode' : 'light_mode';
+        });
+    });
 })();

--- a/precios.html
+++ b/precios.html
@@ -1,35 +1,47 @@
 <!DOCTYPE html>
+<!-- /precios.html -->
+<!-- Admin page to manage menu prices -->
+<!-- Lets staff update product prices and deals -->
+<!-- RELEVANT FILES: js/app.js, js/theme.js -->
 <html lang="es">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Taquería "El Apá" — Administrar Precios</title>
+  <script>tailwind.config = { darkMode: 'class' }</script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="js/theme.js"></script>
   <link rel="stylesheet" href="js/styles.css">
 </head>
-<body class="bg-gray-100 text-gray-800">
+<body>
   <div class="container mx-auto max-w-2xl p-4 md:p-8">
-    <header class="mb-8 text-center">
-      <h1 class="text-4xl md:text-5xl font-bold text-yellow-600">Administrar Menú</h1>
-      <p class="text-gray-600 mt-2">Edita precios, productos y promociones.</p>
-      <a href="index.html" class="mt-4 inline-block text-blue-600 hover:underline">&larr; Volver a las mesas</a>
+    <header class="mb-8 flex flex-col sm:flex-row items-center justify-between text-center sm:text-left">
+      <div>
+        <h1 class="text-4xl md:text-5xl font-bold text-yellow-600">Administrar Menú</h1>
+        <p class="text-gray-600 dark:text-gray-400 mt-2">Edita precios, productos y promociones.</p>
+        <a href="index.html" class="mt-4 inline-block text-blue-600 hover:underline dark:text-blue-400">&larr; Volver a las mesas</a>
+      </div>
+      <button id="theme-toggle" class="mt-4 sm:mt-0 p-2 rounded-full bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600">
+        <span id="theme-icon" class="material-icons">dark_mode</span>
+      </button>
     </header>
 
-    <section class="bg-white p-6 rounded-xl shadow relative overflow-hidden">
+    <section class="bg-white dark:bg-gray-800 p-6 rounded-xl shadow relative overflow-hidden">
         <div>
           <label class="flex items-center gap-3 mb-4 select-none cursor-pointer"><input id="promo-enabled" type="checkbox" class="w-5 h-5"><span class="font-medium">2×1 en <strong>Pastor</strong> disponible</span></label>
-          <p class="text-xs text-gray-500 -mt-2 mb-4">Si está activo, <em>Taco de Pastor</em> cobra <code>ceil(q/2)</code>. Úsalo para apagar la promo aun en lunes/miércoles.</p>
+          <p class="text-xs text-gray-500 dark:text-gray-400 -mt-2 mb-4">Si está activo, <em>Taco de Pastor</em> cobra <code>ceil(q/2)</code>. Úsalo para apagar la promo aun en lunes/miércoles.</p>
           <div id="price-editor" class="space-y-3"></div>
           <div class="mt-5 border-t pt-5">
             <h3 class="font-semibold mb-2">Agregar producto</h3>
             <div class="flex flex-col gap-3">
-              <input id="new-item-name" type="text" placeholder="Nombre del producto" class="p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent">
-              <div class="relative"><span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span><input id="new-item-price" type="number" min="0" step="0.50" placeholder="Precio" class="w-full pl-6 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent"></div>
-              <button id="add-item" class="bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-6 py-3 rounded-lg">Agregar</button>
+              <input id="new-item-name" type="text" placeholder="Nombre del producto" class="p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100">
+              <div class="relative"><span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 dark:text-gray-400">$</span><input id="new-item-price" type="number" min="0" step="0.50" placeholder="Precio" class="w-full pl-6 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"></div>
+              <button id="add-item" class="bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-6 py-3 rounded-lg dark:bg-emerald-600 dark:hover:bg-emerald-500">Agregar</button>
             </div>
           </div>
-          <button id="save-prices" class="mt-6 w-full bg-green-500 hover:bg-green-600 text-white font-semibold py-2 rounded-lg">Guardar Cambios</button>
+          <button id="save-prices" class="mt-6 w-full bg-green-500 hover:bg-green-600 text-white font-semibold py-2 rounded-lg dark:bg-green-600 dark:hover:bg-green-500">Guardar Cambios</button>
         </div>
       </section>
   </div>
@@ -50,8 +62,8 @@
             App.$('#promo-enabled').checked = !!App.AppState.promoEnabled;
             App.AppState.items.forEach(it => {
                 const row = document.createElement('div');
-                row.className = 'flex items-center justify-between bg-gray-50 rounded-lg p-3 gap-3';
-                row.innerHTML = `<div class="min-w-0 flex items-center gap-2"><span class="font-medium text-gray-700 truncate">${it.label}</span> ${it.id === 'taco_pastor' ? `<span class="badge ${App.AppState.promoEnabled ? 'bg-red-500 text-white' : 'bg-gray-200 text-gray-700'}">2×1</span>` : (it.base ? '' : `<span class="badge bg-blue-100 text-blue-700">custom</span>`)}</div><div class="flex items-center gap-2 shrink-0"><div class="relative"><span class="absolute left-2 top-1/2 -translate-y-1/2 text-gray-500 select-none">$</span><input type="number" step="0.50" id="price_${it.id}" value="${(App.AppState.prices[it.id] || 0).toFixed(2)}" class="w-28 sm:w-24 pl-5 p-2 border rounded-md text-right focus:ring-2 focus:ring-yellow-500"></div> ${it.base ? '' : `<button data-del="${it.id}" class="text-red-600 hover:text-red-700 text-sm">Eliminar</button>`}</div>`;
+                row.className = 'flex items-center justify-between bg-gray-50 dark:bg-gray-700 rounded-lg p-3 gap-3';
+                row.innerHTML = `<div class="min-w-0 flex items-center gap-2"><span class="font-medium text-gray-700 dark:text-gray-100 truncate">${it.label}</span> ${it.id === 'taco_pastor' ? `<span class="badge ${App.AppState.promoEnabled ? 'bg-red-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-600 dark:text-gray-200'}">2×1</span>` : (it.base ? '' : `<span class="badge bg-blue-100 text-blue-700">custom</span>`)}</div><div class="flex items-center gap-2 shrink-0"><div class="relative"><span class="absolute left-2 top-1/2 -translate-y-1/2 text-gray-500 dark:text-gray-400 select-none">$</span><input type="number" step="0.50" id="price_${it.id}" value="${(App.AppState.prices[it.id] || 0).toFixed(2)}" class="w-28 sm:w-24 pl-5 p-2 border rounded-md text-right focus:ring-2 focus:ring-yellow-500 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"></div> ${it.base ? '' : `<button data-del="${it.id}" class="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 text-sm">Eliminar</button>`}</div>`;
                 container.appendChild(row);
             });
         }


### PR DESCRIPTION
## Summary
- consolidate dark/light theme handling in `theme.js`
- add dark mode toggle and styles to `precios.html`
- centralize base colors for themes in `styles.css`
- ensure Cobrada badges adapt to light mode

## Testing
- `node --check js/theme.js`


------
https://chatgpt.com/codex/tasks/task_e_68c72dc960b08320bdd7a3c6685e5134