### PR TITLE
fix: improve dark mode initialization

### DIFF
--- a/js/styles.css
+++ b/js/styles.css
@@ -11,15 +11,18 @@
   --text-dark: #f3f4f6;
 }
 
+/* Ensure dark mode styles are properly scoped */
+html.dark body {
+  background-color: var(--bg-dark);
+  color: var(--text-dark);
+}
+
+/* Add transition for smooth theme switching */
 body {
   font-family: 'Inter', sans-serif;
   background-color: var(--bg-light);
   color: var(--text-light);
-}
-
-.dark body {
-  background-color: var(--bg-dark);
-  color: var(--text-dark);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .card { transition: transform .2s ease, box-shadow .2s ease, border-color .3s ease; }

--- a/js/theme.js
+++ b/js/theme.js
@@ -6,26 +6,50 @@
 (function() {
     const root = document.documentElement;
 
+    // Apply or remove the dark class and remember the choice
     function applyTheme(isDark) {
-        root.classList.toggle('dark', isDark);
-        localStorage.theme = isDark ? 'dark' : 'light';
+        if (isDark) {
+            root.classList.add('dark');
+        } else {
+            root.classList.remove('dark');
+        }
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
     }
 
-    // Set initial theme early
-    applyTheme(localStorage.theme === 'dark');
+    // Get stored theme or fall back to system preference
+    function getStoredTheme() {
+        const stored = localStorage.getItem('theme');
+        if (stored) {
+            return stored === 'dark';
+        }
+        return window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+
+    // Set initial theme immediately
+    const initialTheme = getStoredTheme();
+    applyTheme(initialTheme);
 
     document.addEventListener('DOMContentLoaded', () => {
         const btn = document.getElementById('theme-toggle');
         const icon = document.getElementById('theme-icon');
+
         if (!btn || !icon) {
             console.warn('Theme toggle elements not found');
             return;
         }
-        icon.textContent = root.classList.contains('dark') ? 'light_mode' : 'dark_mode';
+
+        // Update icon based on current theme
+        function updateIcon() {
+            const isDark = root.classList.contains('dark');
+            icon.textContent = isDark ? 'light_mode' : 'dark_mode';
+        }
+
+        updateIcon();
+
         btn.addEventListener('click', () => {
             const isDark = root.classList.contains('dark');
             applyTheme(!isDark);
-            icon.textContent = isDark ? 'dark_mode' : 'light_mode';
+            updateIcon();
         });
     });
 })();


### PR DESCRIPTION
## Summary
- apply theme immediately using stored or system preference
- scope dark mode CSS to `html` and add color transition

## Testing
- `node --check js/theme.js`


------
https://chatgpt.com/codex/tasks/task_e_68c79834e9608320a33763dacc37579b