### PR TITLE
Fix dark/light theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <script src="js/theme.js"></script>
   <link rel="stylesheet" href="js/styles.css">
   <link rel="manifest" href="./manifest.webmanifest">
-  <meta name="theme-color" content="#f59e0b">
+  <meta id="theme-color" name="theme-color" content="#f59e0b">
   <link rel="apple-touch-icon" href="icons/icon-192.png">
 </head>
   <body>

--- a/js/styles.css
+++ b/js/styles.css
@@ -11,6 +11,10 @@
   --text-dark: #f3f4f6;
 }
 
+/* Use color-scheme so browser UI matches theme */
+html { color-scheme: light; }
+html.dark { color-scheme: dark; }
+
 /* Ensure dark mode styles are properly scoped */
 html.dark body {
   background-color: var(--bg-dark);

--- a/js/theme.js
+++ b/js/theme.js
@@ -5,51 +5,41 @@
 
 (function() {
     const root = document.documentElement;
+    const meta = document.querySelector('meta[name="theme-color"]');
 
-    // Apply or remove the dark class and remember the choice
-    function applyTheme(isDark) {
-        if (isDark) {
-            root.classList.add('dark');
-        } else {
-            root.classList.remove('dark');
-        }
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    // Switch theme and remember choice
+    function setTheme(mode) {
+        const isDark = mode === 'dark';
+        root.classList.toggle('dark', isDark);
+        localStorage.setItem('theme', mode);
+        if (meta) meta.setAttribute('content', isDark ? '#111827' : '#f59e0b');
     }
 
-    // Get stored theme or fall back to system preference
-    function getStoredTheme() {
+    // Determine starting theme
+    function getTheme() {
         const stored = localStorage.getItem('theme');
-        if (stored) {
-            return stored === 'dark';
-        }
-        return window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (stored) return stored;
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
 
-    // Set initial theme immediately
-    const initialTheme = getStoredTheme();
-    applyTheme(initialTheme);
+    // Apply theme ASAP
+    setTheme(getTheme());
 
     document.addEventListener('DOMContentLoaded', () => {
         const btn = document.getElementById('theme-toggle');
         const icon = document.getElementById('theme-icon');
+        if (!btn || !icon) return;
 
-        if (!btn || !icon) {
-            console.warn('Theme toggle elements not found');
-            return;
-        }
-
-        // Update icon based on current theme
         function updateIcon() {
-            const isDark = root.classList.contains('dark');
-            icon.textContent = isDark ? 'light_mode' : 'dark_mode';
+            icon.textContent = root.classList.contains('dark') ? 'light_mode' : 'dark_mode';
         }
-
-        updateIcon();
 
         btn.addEventListener('click', () => {
-            const isDark = root.classList.contains('dark');
-            applyTheme(!isDark);
+            const mode = root.classList.contains('dark') ? 'light' : 'dark';
+            setTheme(mode);
             updateIcon();
         });
+
+        updateIcon();
     });
 })();

--- a/precios.html
+++ b/precios.html
@@ -14,6 +14,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="js/theme.js"></script>
   <link rel="stylesheet" href="js/styles.css">
+  <meta id="theme-color" name="theme-color" content="#f59e0b">
 </head>
 <body>
   <div class="container mx-auto max-w-2xl p-4 md:p-8">


### PR DESCRIPTION
## Summary
- refactor theme script to reliably toggle dark mode and update browser color
- add theme color meta tag to both pages
- ensure browser UI follows theme via color-scheme css

## Testing
- `node --check js/theme.js`


------
https://chatgpt.com/codex/tasks/task_e_68c79c17ab448320806756d8bff202d6