### PR TITLE
Remove footer version display

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,9 +68,6 @@
       <div id="tables-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"></div>
     </section>
 
-    <footer class="mt-8 text-center text-xs text-gray-500 dark:text-gray-400">
-      <span>Versión: </span><span id="app-version" class="font-medium">cargando…</span><span id="net-status" class="ml-2"></span>
-    </footer>
   </div>
   
   <div id="tip-modal" class="modal hidden fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-[10001]">

--- a/js/app.js
+++ b/js/app.js
@@ -91,9 +91,9 @@
     App.handleSW = function() {
         const versionEl = App.$('#app-version');
         const statusEl = App.$('#net-status');
-        if (!versionEl || !statusEl) return;
 
         const updateNetStatus = () => {
+            if (!statusEl) return;
             statusEl.textContent = navigator.onLine ? '· en línea' : '· sin conexión';
             statusEl.className = navigator.onLine ? 'ml-2 text-emerald-600' : 'ml-2 text-red-600';
         };
@@ -120,6 +120,7 @@
         }
 
         async function showVersion() {
+            if (!versionEl) return;
             try {
                 const version = await requestSwVersion({ timeoutMs: 2500 });
                 versionEl.textContent = version;
@@ -129,16 +130,16 @@
                 versionEl.textContent = cachedVersion ? `${cachedVersion} (cache)` : "desconocida";
             }
         }
-        
+
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
                 navigator.serviceWorker.register('./service-worker.js')
                     .then(() => navigator.serviceWorker.ready)
                     .then(() => {
                         updateNetStatus();
-                        showVersion();
+                        return showVersion();
                     }).catch(() => {
-                        versionEl.textContent = 'sin SW';
+                        if (versionEl) versionEl.textContent = 'sin SW';
                         updateNetStatus();
                     });
             });
@@ -147,7 +148,7 @@
                 setTimeout(showVersion, 400);
             });
         } else {
-            versionEl.textContent = 'no compatible';
+            if (versionEl) versionEl.textContent = 'no compatible';
             updateNetStatus();
         }
         window.addEventListener('online', updateNetStatus);


### PR DESCRIPTION
## Summary
- remove the footer version display from the main page
- keep service worker registration while making the version UI optional

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb5f2e96708320917b06acdbf0e715