### PR TITLE
Polish printed receipt layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,25 +393,96 @@
         function printBill(tableId) {
             const table = App.AppState.tables.find(t => t.id === tableId);
             if (!table) return;
-            let itemsHtml = "";
-              Object.entries(table.order).forEach(([itemId, qty]) => {
-                  const item = App.AppState.items.find(i => i.id === itemId);
-                  const line = App.computeLine(itemId, qty);
-                  itemsHtml += `<tr><td class="qty">${qty}x</td><td class="item">${item ? item.label : "Item"}</td><td class="price">${App.money(line.total)}</td></tr>`;
-              });
-              const subtotal = App.computeTableTotal(table);
-              const tipHtml = table.tip ? `<h2 class="text-right">PROPINA: ${App.money(table.tip)}</h2>` : '';
-              const totalHtml = table.tip ? `<h2 class="text-right">TOTAL: ${App.money(subtotal + table.tip)}</h2>` : '';
-              const ticketHtml = `<div id="print-area"><div class="receipt-brand"><img src="icons/icon-192.png" alt="Logo de Taquería El Apá" class="receipt-brand-logo"/><h1 class=\"receipt-brand-name\">Taquería \"El Apá\"</h1><p class=\"receipt-brand-tagline\">Sabor auténtico cada día</p></div><hr><p><b>Mesa:</b> ${table.name}</p><p><b>Fecha:</b> ${new Date().toLocaleString()}</p><hr><table>${itemsHtml}</table><hr><h2 class=\"text-right\">SUBTOTAL: ${App.money(subtotal)}</h2>${tipHtml}${totalHtml}</div>`;
-              const iframe = document.createElement("iframe");
-              iframe.style.display = "none";
-              document.body.appendChild(iframe);
-              const doc = iframe.contentDocument;
+
+            const orderEntries = Object.entries(table.order || {});
+            const rowsHtml = orderEntries.length
+                ? orderEntries.map(([itemId, qty]) => {
+                    const item = App.AppState.items.find(i => i.id === itemId);
+                    const line = App.computeLine(itemId, qty);
+                    return `<tr><td class="qty">${qty}x</td><td class="item">${item ? item.label : "Item"}</td><td class="price">${App.money(line.total)}</td></tr>`;
+                }).join("")
+                : '<tr><td class="receipt-empty" colspan="3">Sin productos</td></tr>';
+            const subtotal = App.computeTableTotal(table);
+            const tip = table.tip || 0;
+            const issuedAt = new Date().toLocaleString();
+
+            // Build inline CSS so the iframe ticket keeps our styling when it prints.
+            const styleContent = `
+body{font-family:'Courier New',Courier,monospace;font-size:10pt;margin:0;padding:0}
+h1,h2,h3,p{margin:0}
+#print-area{width:100%;padding:8px 0}
+.receipt-brand{text-align:center;margin-bottom:8px}
+.receipt-brand-logo{width:48px;height:48px;object-fit:contain;margin:0 auto 4px;display:block}
+.receipt-brand-name{font-size:14pt;letter-spacing:1px}
+.receipt-brand-tagline{font-size:8pt;text-transform:uppercase;letter-spacing:1px}
+.receipt-meta{margin:6px 0;font-size:9pt;display:flex;flex-direction:column;gap:2px}
+.receipt-meta-row{display:flex;justify-content:space-between}
+.receipt-meta-label{font-weight:700;letter-spacing:.5px;text-transform:uppercase}
+.receipt-table{width:100%;border-collapse:collapse;margin-top:4px}
+.receipt-table colgroup col:first-child{width:18%}
+.receipt-table colgroup col:nth-child(2){width:52%}
+.receipt-table colgroup col:last-child{width:30%}
+.receipt-table th,.receipt-table td{padding:4px 2px}
+.receipt-table th{font-size:8pt;font-weight:700;text-transform:uppercase;letter-spacing:.8px;text-align:left;border-bottom:1px solid #000}
+.receipt-table td.qty{text-align:left}
+.receipt-table td.item{text-align:left}
+.receipt-table td.price{text-align:right}
+.receipt-table tbody tr+tr td{border-top:1px dotted #9ca3af}
+.receipt-table .receipt-empty{text-align:center;font-style:italic;padding:8px 0}
+.receipt-summary{margin-top:8px;display:flex;flex-direction:column;gap:2px;font-size:10pt}
+.receipt-summary-row{display:flex;justify-content:space-between}
+.receipt-summary-row.total{font-weight:700;border-top:1px solid #000;margin-top:4px;padding-top:4px}
+.text-right{text-align:right}
+hr{border:0;border-top:1px dashed #000;margin:6px 0}
+            `.trim();
+
+            const tipRow = tip
+                ? `<div class='receipt-summary-row'><span>Propina</span><span>${App.money(tip)}</span></div>`
+                : "";
+
+            // Compose the printable ticket markup with metadata, order lines, and totals.
+            const ticketHtml = `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Ticket ${table.name}</title>
+  <style>${styleContent}</style>
+</head>
+<body>
+  <div id="print-area">
+    <div class="receipt-brand">
+      <img src="icons/icon-192.png" alt="Logo de Taquería El Apá" class="receipt-brand-logo"/>
+      <h1 class="receipt-brand-name">Taquería &quot;El Apá&quot;</h1>
+      <p class="receipt-brand-tagline">Sabor auténtico cada día</p>
+    </div>
+    <hr>
+    <div class="receipt-meta">
+      <div class="receipt-meta-row"><span class="receipt-meta-label">Mesa</span><span>${table.name}</span></div>
+      <div class="receipt-meta-row"><span class="receipt-meta-label">Fecha</span><span>${issuedAt}</span></div>
+    </div>
+    <hr>
+    <table class="receipt-table">
+      <colgroup><col><col><col></colgroup>
+      <thead><tr><th>Cant</th><th>Producto</th><th class="text-right">Total</th></tr></thead>
+      <tbody>${rowsHtml}</tbody>
+    </table>
+    <div class="receipt-summary">
+      <div class="receipt-summary-row"><span>Subtotal</span><span>${App.money(subtotal)}</span></div>
+      ${tipRow}
+      <div class="receipt-summary-row total"><span>Total</span><span>${App.money(subtotal + tip)}</span></div>
+    </div>
+  </div>
+</body>
+</html>`;
+
+            const iframe = document.createElement("iframe");
+            iframe.style.display = "none";
+            document.body.appendChild(iframe);
+            const doc = iframe.contentDocument || iframe.contentWindow.document;
+            doc.open();
             doc.write(ticketHtml);
-            const style = doc.createElement("style");
-            style.textContent = `body{font-family:'Courier New',Courier,monospace;font-size:10pt;margin:0;padding:0} h1,h2,p{margin:0} #print-area{width:100%;padding:8px 0} .receipt-brand{text-align:center;margin-bottom:8px} .receipt-brand-logo{width:48px;height:48px;object-fit:contain;margin:0 auto 4px;display:block} .receipt-brand-name{font-size:14pt;letter-spacing:1px} .receipt-brand-tagline{font-size:8pt;text-transform:uppercase;letter-spacing:1px} table{width:100%;border-collapse:collapse;margin-top:4px} th,td{padding:4px 2px} td.qty{width:18%;text-align:left} td.item{width:52%} td.price{width:30%;text-align:right} h2{font-size:10pt;font-weight:700;margin:4px 0} .text-right{text-align:right} hr{border:0;border-top:1px dashed #000;margin:6px 0}`;
-            doc.head.appendChild(style);
-            doc.close(); // Important for some browsers
+            doc.close();
+            iframe.contentWindow.focus();
             iframe.contentWindow.print();
             document.body.removeChild(iframe);
         }

--- a/js/styles.css
+++ b/js/styles.css
@@ -70,11 +70,61 @@ input[type="number"] { -moz-appearance: textfield; }
   .receipt-brand-tagline {
     font-size: 8pt; text-transform: uppercase; letter-spacing: 1px;
   }
-  table { width: 100%; border-collapse: collapse; margin-top: 4px; }
-  th, td { padding: 4px 2px; }
-  td.qty { width: 18%; text-align: left; }
-  td.item { width: 52%; }
-  td.price { width: 30%; text-align: right; }
+  .receipt-meta {
+    margin: 6px 0;
+    font-size: 9pt;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .receipt-meta-row {
+    display: flex;
+    justify-content: space-between;
+  }
+  .receipt-meta-label {
+    font-weight: 700;
+    letter-spacing: .5px;
+    text-transform: uppercase;
+  }
+  .receipt-table { width: 100%; border-collapse: collapse; margin-top: 4px; }
+  .receipt-table colgroup col:first-child { width: 18%; }
+  .receipt-table colgroup col:nth-child(2) { width: 52%; }
+  .receipt-table colgroup col:last-child { width: 30%; }
+  .receipt-table th, .receipt-table td { padding: 4px 2px; }
+  .receipt-table th {
+    font-size: 8pt;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .8px;
+    text-align: left;
+    border-bottom: 1px solid #000;
+  }
+  .receipt-table td.qty { text-align: left; }
+  .receipt-table td.item { text-align: left; }
+  .receipt-table td.price { text-align: right; }
+  .receipt-table tbody tr + tr td { border-top: 1px dotted #9ca3af; }
+  .receipt-table .receipt-empty {
+    text-align: center;
+    font-style: italic;
+    padding: 8px 0;
+  }
+  .receipt-summary {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 10pt;
+  }
+  .receipt-summary-row {
+    display: flex;
+    justify-content: space-between;
+  }
+  .receipt-summary-row.total {
+    font-weight: 700;
+    border-top: 1px solid #000;
+    margin-top: 4px;
+    padding-top: 4px;
+  }
   .text-right { text-align: right; }
   hr { border: 0; border-top: 1px dashed black; margin: 6px 0; }
 }


### PR DESCRIPTION
## Summary
- restructure the printed ticket markup to include receipt metadata, headers, and totals for clarity
- embed an inline stylesheet when printing so the iframe keeps the updated layout
- refresh the shared print CSS with receipt meta, table, and summary utilities for consistent spacing

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db49f96f088320b144733fefb551f5