### PR TITLE
Fix: Define openReportModal to resolve ReferenceError

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,10 +556,15 @@ hr{border:0;border-top:1px dashed #000;margin:6px 0}
             }
         }
 
+        function openReportModal() {
+            renderDailyReport();
+            App.$("#report-modal").classList.remove("hidden");
+        }
+
         function wireEvents() {
             App.$('#add-table').addEventListener('click', addTable);
             App.$('#close-all').addEventListener('click', closeAllTables);
-            App.$('#show-report').addEventListener('click', () => { renderDailyReport(); App.$("#report-modal").classList.remove("hidden"); });
+            App.$('#show-report').addEventListener('click', openReportModal);
             App.$('#report-close').addEventListener('click', () => App.$("#report-modal").classList.add("hidden"));
             App.$('#tables-grid').addEventListener('click', e => { const t = e.target.closest('[data-table-id]')?.dataset.tableId; if (t) { const a = App.AppState.tables.find(e => e.id === t); openDrawer(a); } });
             App.$('#drawer-close').addEventListener('click', closeDrawer);


### PR DESCRIPTION
The application threw a `ReferenceError` when the page was loaded with the `?action=showReport` URL parameter. This was because the `openReportModal` function was called in the initialization script but was not defined anywhere in the scope.

This change defines the `openReportModal` function in `index.html`. The function encapsulates the logic to render the daily report and display the modal.

This resolves the error, allowing the report modal shortcut to function as intended. The "Show Report" button's click handler has also been updated to use this new function for better code consistency.