### PR TITLE
Adjust Mesas header layout for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,16 +65,16 @@
 
     <section class="relative z-0">
       <div class="sticky top-0 bg-gray-100 dark:bg-gray-900 z-10 pb-2">
-        <div class="flex items-center justify-between">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <h2 class="text-2xl font-bold text-gray-700 dark:text-gray-100">Mesas</h2>
-          <div class="text-right">
+          <div class="w-full sm:w-auto text-left sm:text-right space-y-3 sm:space-y-2">
             <div id="grand-total" class="text-xl font-extrabold dark:text-gray-100">TOTAL (activas): $0.00</div>
-            <div class="flex gap-2 justify-end mt-2">
-                <button id="show-report" class="text-sm bg-yellow-600 hover:bg-yellow-700 text-white px-3 py-1.5 rounded-lg inline-flex items-center dark:bg-yellow-700 dark:hover:bg-yellow-600">
+            <div class="flex flex-col sm:flex-row gap-2 sm:justify-end">
+                <button id="show-report" class="text-sm bg-yellow-600 hover:bg-yellow-700 text-white px-3 py-1.5 rounded-lg inline-flex items-center justify-center w-full sm:w-auto dark:bg-yellow-700 dark:hover:bg-yellow-600">
                   <span class="material-icons mr-1" aria-hidden="true">assessment</span>
                   Reporte del Día
                 </button>
-                <button id="close-all" class="text-sm bg-yellow-600 hover:bg-yellow-700 text-white px-3 py-1.5 rounded-lg inline-flex items-center dark:bg-yellow-700 dark:hover:bg-yellow-600">
+                <button id="close-all" class="text-sm bg-yellow-600 hover:bg-yellow-700 text-white px-3 py-1.5 rounded-lg inline-flex items-center justify-center w-full sm:w-auto dark:bg-yellow-700 dark:hover:bg-yellow-600">
                   <span class="material-icons mr-1" aria-hidden="true">point_of_sale</span>
                   Cobrar & Cerrar todas
                 </button>


### PR DESCRIPTION
## Summary
- rework the Mesas header container to stack vertically on small screens
- allow the Mesas action buttons to stretch full-width on mobile for better spacing

## Testing
- Manual: Viewed index.html in a 390x844 mobile viewport


------
https://chatgpt.com/codex/tasks/task_e_68e30d5684e483208fc46b28017ab219