### PR TITLE
Add Ticket Creation Screen

### DIFF
--- a/js/ticket.js
+++ b/js/ticket.js
@@ -1,0 +1,347 @@
+// js/ticket.js
+// Handles the logic for the Ticket Creation screen.
+// Allows adding items to a draft order and committing it to a table.
+// RELEVANT FILES: ticket.html, js/app.js
+
+document.addEventListener('DOMContentLoaded', () => {
+    const App = window.TaqueriaApp;
+    if (!App) {
+        console.error('TaqueriaApp not initialized');
+        return;
+    }
+
+    // State
+    let currentTableId = null;
+    let draftOrder = {}; // { itemId: qty }
+    let currentCategory = 'tacos'; // Default category
+    let tableData = null; // The table object if editing existing
+    let modalItem = null; // ID of item currently in modal
+
+    // DOM Elements
+    const els = {
+        tableName: document.getElementById('table-name'),
+        tableMeta: document.getElementById('table-meta'),
+        commitBtn: document.getElementById('commit-btn'),
+        commitTotal: document.getElementById('commit-total'),
+        categoryNav: document.getElementById('category-nav'),
+        productGrid: document.getElementById('product-grid'),
+        trayHandle: document.getElementById('tray-handle'),
+        trayList: document.getElementById('tray-list'),
+        trayCount: document.getElementById('tray-count'),
+        trayTotal: document.getElementById('tray-total'),
+        modal: document.getElementById('modifier-modal'),
+        modalTitle: document.getElementById('modal-title'),
+        modalOptions: document.getElementById('modal-options'),
+        modalClose: document.getElementById('modal-close'),
+        modalUpdate: document.getElementById('modal-update-btn'),
+        modalQtyMinus: document.getElementById('modal-qty-minus'),
+        modalQtyPlus: document.getElementById('modal-qty-plus'),
+        modalQtyVal: document.getElementById('modal-qty-val'),
+    };
+
+    function init() {
+        App.loadState();
+
+        // Parse URL
+        const urlParams = new URLSearchParams(window.location.search);
+        currentTableId = urlParams.get('tableId');
+
+        if (currentTableId) {
+            tableData = App.AppState.tables.find(t => t.id === currentTableId);
+            if (tableData) {
+                // Clone existing order to draft
+                draftOrder = { ...tableData.order };
+            } else {
+                // Table ID provided but not found? Treat as new or error.
+                // We'll treat as new with that ID (unlikely scenario), or just ignore.
+                currentTableId = null;
+            }
+        }
+
+        renderHeader();
+        renderCategories();
+        renderGrid();
+        renderTray();
+        wireEvents();
+    }
+
+    function renderHeader() {
+        if (tableData) {
+            els.tableName.innerHTML = `${tableData.name} <span class="text-text-muted font-mono text-sm align-middle ml-1">[DRAFT]</span>`;
+            const now = Date.now();
+            const elapsed = now - (tableData.createdAt || now);
+            const minutes = Math.floor(elapsed / 60000);
+            const pad = n => n.toString().padStart(2, '0');
+            const hh = Math.floor(minutes / 60);
+            const mm = minutes % 60;
+            els.tableMeta.textContent = `INCIDENT #${tableData.id.slice(-4).toUpperCase()} • WAIT: ${pad(hh)}:${pad(mm)}`;
+        } else {
+            els.tableName.innerHTML = `NEW TABLE <span class="text-text-muted font-mono text-sm align-middle ml-1">[DRAFT]</span>`;
+            els.tableMeta.textContent = `NEW TICKET • WAIT: 00:00`;
+        }
+    }
+
+    function renderCategories() {
+        const categories = ['tacos', 'bebidas', 'postres', 'extras']; // Fixed list from design or dynamic?
+        // Let's use dynamic but ensure Tacos is first as per design
+        const dynCategories = [...new Set(App.AppState.items.map(i => i.category || 'otros'))];
+        // Merge/Sort
+        const order = ['tacos', 'bebidas', 'postres', 'extras', 'otros'];
+        const sortedCats = Array.from(new Set([...order, ...dynCategories])).filter(c => dynCategories.includes(c) || order.includes(c));
+
+        els.categoryNav.innerHTML = '';
+        sortedCats.forEach(cat => {
+            const btn = document.createElement('button');
+            const isActive = cat === currentCategory;
+            const activeClasses = "border-primary bg-surface-light text-text-main";
+            const inactiveClasses = "border-transparent text-text-muted hover:bg-surface-light/50 hover:text-text-main";
+
+            btn.className = `flex-1 min-w-[100px] py-3 text-center border-b-4 font-display font-bold text-sm tracking-wide transition-colors uppercase ${isActive ? activeClasses : inactiveClasses}`;
+            btn.textContent = cat;
+            btn.onclick = () => {
+                currentCategory = cat;
+                renderCategories();
+                renderGrid();
+            };
+            els.categoryNav.appendChild(btn);
+        });
+    }
+
+    function renderGrid() {
+        els.productGrid.innerHTML = '';
+        const items = App.AppState.items.filter(i => (i.category || 'otros') === currentCategory);
+
+        if (items.length === 0) {
+            els.productGrid.innerHTML = '<div class="col-span-full text-center text-text-muted py-10 font-mono">NO ITEMS IN CATEGORY</div>';
+            return;
+        }
+
+        items.forEach(item => {
+            const qty = draftOrder[item.id] || 0;
+            const price = App.AppState.prices[item.id] || 0;
+
+            const btn = document.createElement('button');
+            // Check stock status (mocked as true for now)
+            const inStock = true;
+
+            btn.className = "group relative aspect-square bg-white border border-border-strong hover:bg-surface-light active:bg-surface-light transition-colors flex flex-col items-center justify-center p-2 select-none";
+            btn.onclick = (e) => {
+                // If clicking the badge (if we had one separate), open modal?
+                // For now, simple tap = add.
+                addItem(item.id);
+            };
+
+            // HTML Structure
+            let badgeHtml = '';
+            if (qty > 0) {
+                badgeHtml = `<div class="absolute top-2 left-2 bg-black text-white font-mono text-xs w-6 h-6 flex items-center justify-center">${qty}</div>`;
+            }
+
+            btn.innerHTML = `
+                ${badgeHtml}
+                <div class="absolute top-3 right-3 w-2 h-2 rounded-full ${inStock ? 'bg-success' : 'bg-red-500'}"></div>
+                <span class="font-display font-bold text-lg leading-tight mb-1 uppercase text-center">${item.label}</span>
+                <span class="font-mono text-text-muted text-sm">${App.money(price)}</span>
+            `;
+
+            els.productGrid.appendChild(btn);
+        });
+    }
+
+    function renderTray() {
+        els.trayList.innerHTML = '';
+        let total = 0;
+        let count = 0;
+
+        const entries = Object.entries(draftOrder);
+        // Show Tray list if not empty (or always show but handle empty state)
+        if (entries.length === 0) {
+            els.trayList.innerHTML = '<div class="p-4 text-center text-text-muted font-mono text-sm">TRAY IS EMPTY</div>';
+            els.trayList.classList.add('hidden'); // Hide list
+        } else {
+            // els.trayList.classList.remove('hidden'); // Only show if expanded?
+            // The design has a "collapsed view" and a "scrollable list".
+            // We'll toggle visibility on header click, but update content always.
+        }
+
+        entries.forEach(([itemId, qty]) => {
+            const item = App.AppState.items.find(i => i.id === itemId);
+            if (!item || qty <= 0) return;
+
+            const line = App.computeLine(itemId, qty);
+            total += line.total;
+            count += qty;
+
+            const row = document.createElement('div');
+            row.className = "flex items-center justify-between p-4 border-b border-border-subtle group hover:bg-surface-light/50 relative overflow-hidden cursor-pointer";
+            row.onclick = () => openModal(itemId);
+
+            row.innerHTML = `
+                <div class="flex items-start gap-3">
+                    <span class="bg-border-strong text-white font-mono text-xs px-1.5 py-0.5 mt-0.5">${qty}x</span>
+                    <div>
+                        <p class="font-display font-bold text-sm leading-tight uppercase">${item.label}</p>
+                        <p class="font-mono text-xs text-text-muted mt-0.5">TAP TO EDIT</p>
+                    </div>
+                </div>
+                <div class="flex items-center gap-4">
+                    <span class="font-mono text-sm font-medium">${App.money(line.total)}</span>
+                    <div class="w-1 h-8 bg-border-subtle rounded-full"></div>
+                </div>
+            `;
+            els.trayList.appendChild(row);
+        });
+
+        els.trayCount.textContent = `${count} ITEMS`;
+        els.trayTotal.textContent = App.money(total);
+        els.commitTotal.textContent = App.money(total);
+    }
+
+    // Actions
+    function addItem(itemId) {
+        if (!draftOrder[itemId]) draftOrder[itemId] = 0;
+        draftOrder[itemId]++;
+        renderGrid();
+        renderTray();
+    }
+
+    function updateQty(itemId, newQty) {
+        if (newQty <= 0) {
+            delete draftOrder[itemId];
+        } else {
+            draftOrder[itemId] = newQty;
+        }
+        renderGrid();
+        renderTray();
+    }
+
+    // Modal
+    function openModal(itemId) {
+        const item = App.AppState.items.find(i => i.id === itemId);
+        if (!item) return;
+
+        modalItem = itemId;
+        const currentQty = draftOrder[itemId] || 1;
+
+        els.modalTitle.textContent = `CONFIG: ${item.label}`;
+        els.modalQtyVal.textContent = currentQty;
+
+        // Render Modifiers based on category
+        els.modalOptions.innerHTML = '';
+        const category = item.category || 'otros';
+
+        // Define modifiers per category
+        const MODIFIERS = {
+            'tacos': ['Con Todo', 'Sin Cebolla', 'Sin Piña', 'Sin Verdura', 'Tortilla Harina'],
+            'bebidas': ['Con Hielo', 'Sin Hielo', 'Limón'],
+            'postres': [],
+            'extras': []
+        };
+
+        const options = MODIFIERS[category] || [];
+
+        if (options.length === 0) {
+             els.modalOptions.innerHTML = '<p class="text-center text-text-muted text-sm italic">No modifiers available for this item.</p>';
+        } else {
+            options.forEach(opt => {
+                const label = document.createElement('label');
+                label.className = "flex items-center gap-3 p-3 border border-border-subtle cursor-pointer hover:bg-surface-light group select-none";
+                label.innerHTML = `
+                    <div class="relative flex items-center">
+                        <input class="peer h-5 w-5 appearance-none border-2 border-border-strong bg-white checked:bg-primary checked:border-primary transition-colors cursor-pointer" type="checkbox"/>
+                        <span class="material-symbols-outlined absolute text-white text-sm pointer-events-none hidden peer-checked:block left-[2px]">check</span>
+                    </div>
+                    <span class="font-display font-bold text-sm uppercase flex-1">${opt}</span>
+                `;
+                // Add simple toggle behavior (visual only)
+                const checkbox = label.querySelector('input');
+                checkbox.onclick = (e) => {
+                    // Logic to handle exclusive options could go here if needed
+                };
+                els.modalOptions.appendChild(label);
+            });
+        }
+
+        els.modal.classList.remove('hidden');
+    }
+
+    function closeModal() {
+        els.modal.classList.add('hidden');
+        modalItem = null;
+    }
+
+    function commitTicket() {
+        const entries = Object.entries(draftOrder);
+        if (entries.length === 0) {
+            return alert("Ticket is empty!");
+        }
+
+        if (tableData) {
+            // Update existing
+            tableData.order = { ...draftOrder };
+            // Update timestamp only if not charged? Or keep createdAt.
+            // Usually we don't change createdAt.
+        } else {
+            // Create New
+            // Need a name. Design says "Table 04".
+            // We'll prompt for name or generate one.
+            const name = prompt("Enter Table Name / Number:", "Mesa New");
+            if (!name) return;
+
+            const newTable = {
+                id: App.uid(),
+                name: name,
+                note: '',
+                order: { ...draftOrder },
+                charged: false,
+                paidAt: null,
+                createdAt: Date.now(),
+                openDurationMs: null,
+                tip: 0,
+                rounds: [],
+                friends: []
+            };
+            App.AppState.tables.push(newTable);
+        }
+
+        App.persist();
+        window.location.href = "index.html"; // Go back to dashboard
+    }
+
+    // Events
+    function wireEvents() {
+        // Tray Expand/Collapse
+        els.trayHandle.onclick = () => {
+            els.trayList.classList.toggle('hidden');
+            const icon = els.trayHandle.querySelector('.material-symbols-outlined');
+            if (els.trayList.classList.contains('hidden')) {
+                icon.textContent = 'expand_less';
+            } else {
+                icon.textContent = 'expand_more';
+            }
+        };
+
+        // Modal Controls
+        els.modalClose.onclick = closeModal;
+        els.modalQtyMinus.onclick = () => {
+            const val = parseInt(els.modalQtyVal.textContent);
+            if (val > 0) els.modalQtyVal.textContent = val - 1;
+        };
+        els.modalQtyPlus.onclick = () => {
+            const val = parseInt(els.modalQtyVal.textContent);
+            els.modalQtyVal.textContent = val + 1;
+        };
+        els.modalUpdate.onclick = () => {
+            if (modalItem) {
+                const val = parseInt(els.modalQtyVal.textContent);
+                updateQty(modalItem, val);
+                closeModal();
+            }
+        };
+
+        // Commit
+        els.commitBtn.onclick = commitTicket;
+    }
+
+    init();
+});

--- a/ticket.html
+++ b/ticket.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<!-- /ticket.html -->
+<!-- Ticket creation and order management interface -->
+<!-- Allows staff to create orders for tables with a visual grid -->
+<!-- RELEVANT FILES: js/ticket.js, js/app.js, js/theme.js -->
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Anafre - Ticket Creation</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet"/>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<script id="tailwind-config">
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        "primary": "#F50057", // Rosa Mexicano
+                        "background-light": "#FFFFFF",
+                        "background-dark": "#111827",
+                        "surface-light": "#F3F4F6",
+                        "text-main": "#111827",
+                        "text-muted": "#9CA3AF",
+                        "border-subtle": "#E5E7EB",
+                        "border-strong": "#111827",
+                        "alert": "#F59E0B",
+                        "success": "#10B981",
+                    },
+                    fontFamily: {
+                        "display": ["Space Grotesk", "sans-serif"],
+                        "body": ["Inter", "sans-serif"],
+                        "mono": ["JetBrains Mono", "monospace"],
+                    },
+                    borderRadius: {
+                        "DEFAULT": "0px",
+                        "sm": "2px",
+                        "lg": "0px",
+                        "xl": "0px",
+                        "full": "9999px"
+                    },
+                },
+            },
+        }
+    </script>
+<style>
+        /* Custom scrollbar to match the industrial feel */
+        ::-webkit-scrollbar {
+            width: 4px;
+            height: 4px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #F3F4F6;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #9CA3AF;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #111827;
+        }
+        body {
+            min-height: max(884px, 100dvh);
+        }
+    </style>
+    <!-- App Scripts -->
+    <script src="js/theme.js"></script>
+    <script src="js/app.js"></script>
+    <script src="js/ticket.js"></script>
+</head>
+<body class="bg-background-light text-text-main h-screen flex flex-col overflow-hidden font-body">
+<!-- Top Bar: Sticky Header -->
+<header class="shrink-0 border-b border-border-strong bg-white z-20">
+<div class="flex items-center justify-between p-4">
+<div>
+<div class="flex items-center gap-2">
+<span class="material-symbols-outlined text-xl">table_restaurant</span>
+<h1 id="table-name" class="font-display font-bold text-2xl tracking-tight leading-none">LOADING... <span class="text-text-muted font-mono text-sm align-middle ml-1">[DRAFT]</span></h1>
+</div>
+<p id="table-meta" class="text-xs text-text-muted font-mono mt-1">INCIDENT #0000 • WAIT: 00:00</p>
+</div>
+<button id="commit-btn" class="bg-primary hover:bg-primary/90 text-white font-display font-bold text-base px-6 py-3 uppercase tracking-wide flex items-center gap-2 transition-colors">
+<span>Commit Ticket</span>
+<span id="commit-total" class="font-mono bg-black/20 px-1.5 py-0.5 text-sm rounded-sm">$0.00</span>
+</button>
+</div>
+<!-- Categories Rail (Horizontal on Mobile/Tablet) -->
+<nav id="category-nav" class="flex overflow-x-auto border-t border-border-subtle hide-scrollbar">
+    <!-- Categories will be injected here -->
+</nav>
+</header>
+<!-- Main Content Area: Grid + Modal Overlay -->
+<main class="flex-1 relative flex overflow-hidden">
+<!-- Product Grid -->
+<div class="flex-1 overflow-y-auto p-4 pb-32">
+<div id="product-grid" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+    <!-- Products will be injected here -->
+</div>
+</div>
+
+<!-- Modifier Modal -->
+<div id="modifier-modal" class="hidden absolute bottom-0 right-0 left-0 top-0 z-30 bg-black/40 backdrop-blur-[2px] flex items-end sm:items-center justify-center p-4">
+<div class="bg-white border-2 border-border-strong w-full max-w-md shadow-2xl pointer-events-auto animate-in slide-in-from-bottom-10 fade-in duration-200">
+<div class="bg-border-strong text-white p-3 flex justify-between items-center">
+<h3 id="modal-title" class="font-display font-bold uppercase tracking-wide">Config: Item</h3>
+<button id="modal-close" class="text-white hover:text-primary transition-colors">
+<span class="material-symbols-outlined">close</span>
+</button>
+</div>
+<div id="modal-options" class="p-4 space-y-3">
+    <!-- Options injected here -->
+</div>
+<div class="p-4 pt-0">
+    <div class="flex items-center justify-between mb-4">
+        <span class="font-mono text-sm">QUANTITY</span>
+        <div class="flex items-center gap-3">
+             <button id="modal-qty-minus" class="w-8 h-8 flex items-center justify-center bg-surface-light border border-border-strong font-bold text-lg hover:bg-border-strong hover:text-white transition-colors">-</button>
+             <span id="modal-qty-val" class="font-mono font-bold text-xl w-8 text-center">1</span>
+             <button id="modal-qty-plus" class="w-8 h-8 flex items-center justify-center bg-surface-light border border-border-strong font-bold text-lg hover:bg-border-strong hover:text-white transition-colors">+</button>
+        </div>
+    </div>
+<button id="modal-update-btn" class="w-full bg-border-strong text-white font-display font-bold uppercase py-3 hover:bg-black transition-colors">
+                        Update Configuration
+                    </button>
+</div>
+</div>
+</div>
+</main>
+<!-- Tray Summary / Mini-Cart -->
+<footer class="bg-white border-t-2 border-border-strong shrink-0 z-40 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
+<!-- Handle / Collapsed View -->
+<div id="tray-handle" class="flex items-center justify-between px-4 py-3 cursor-pointer bg-surface-light border-b border-border-subtle">
+<div class="flex items-center gap-2 text-text-muted text-sm font-mono uppercase">
+<span class="material-symbols-outlined text-lg">expand_less</span>
+<span>Tray Summary</span>
+</div>
+<div class="text-right">
+<span id="tray-count" class="font-display font-bold text-text-main">0 ITEMS</span>
+</div>
+</div>
+<!-- Scrollable List (Limited Height) -->
+<div id="tray-list" class="max-h-48 overflow-y-auto hidden">
+    <!-- Cart items injected here -->
+</div>
+<!-- Total Row -->
+<div class="p-4 bg-background-light flex justify-between items-center border-t border-border-strong">
+<span class="font-display font-bold text-lg text-text-muted">TOTAL PENDING</span>
+<span id="tray-total" class="font-mono font-bold text-xl tracking-tight">$0.00</span>
+</div>
+</footer>
+</body></html>


### PR DESCRIPTION
Added a new "Ticket Creation" screen (`ticket.html`) and associated logic (`js/ticket.js`). This screen allows staff to create new orders or edit existing ones in a "draft" mode before committing them. It features a brutalist design consistent with the provided reference, a product grid with category filtering, a tray summary, and a modifier modal. The implementation integrates with the existing `TaqueriaApp` state management.

---
*PR created automatically by Jules for task [2613097280604585346](https://jules.google.com/task/2613097280604585346) started by @erickosanchezj*